### PR TITLE
create LICENSE.md file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dimpesh Malviya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi there, I see that you reference in both the [README](https://github.com/dimpeshmalviya/JavaBasicPrograms?tab=readme-ov-file#-license) and the [CONTRIBUTION guide](https://github.com/dimpeshmalviya/JavaBasicPrograms/blob/main/CONTRIBUTION.md?plain=1#L133) that you want to license this project as MIT. However, https://img.shields.io/github/license/dimpeshmalviya/JavaBasicPrograms?style=for-the-badge&color=green referenced in the README returns "License: Not Specified". I'm hoping the addition of this file will clear that up so everything can clearly state "MIT". 

Grabbed the text from https://opensource.org/license/mit and put this year and your name as a guess, but open to changing that. 

Thanks!